### PR TITLE
Add flow server auto-start and compile commands

### DIFF
--- a/layers/+lang/flow-type/README.org
+++ b/layers/+lang/flow-type/README.org
@@ -5,8 +5,22 @@ This layer adds some [[https://flowtype.org/][flow]] related functionality to Em
  - Show the flow-type of the object under the cursor using Eldoc
  - Add flow checking to flycheck (based on the flycheck-flow package)
  - company-mode completion using company-flow
+ - "compilation" using =flow status= and =flow check=
+ - auto staring =flow server= in a project specific comint buffer
 
 * Install
 To use this configuration layer, add it to your =~/.spacemacs=. You will need to
 add =flow-type= to the existing =dotspacemacs-configuration-layers= list in this
 file. Please ensure you already have the flow binary installed and in your PATH.
+
+To prevent the flow server from auto-starting, set =flow-type/no-auto-start= to =t=.
+To start the server in a comint buffer on entering a =js2-mode= buffer, set it to ='process=.
+
+#+BEGIN_SRC emacs-lisp
+(flow-type :variables flow-type/no-auto-start 'process)
+#+END_SRC
+
+* js2-mode key bindings
+  | ,fs | flow-type/show-start-server | show flow server buffer, starting if necessary |
+  | ,fc | flow-type/status            | run `flow status' as a compiler                |
+  | ,fC | flow-type/check             | run `flow check' as a compiler                 |

--- a/layers/+lang/flow-type/config.el
+++ b/layers/+lang/flow-type/config.el
@@ -1,0 +1,15 @@
+(defvar flow-type/no-auto-start nil
+  "Set flow server auto-start behaviour.
+
+Possible values:
+
+nil
+  do nothing
+
+not nil
+  add `--no-auto-start' to all relevant flow commands
+
+'process
+  add `--no-auto-start' to all relevant flow commands, and on entry to a
+  `js2-mode' buffer call `flow-type/ensure-server-buffer' which runs `flow
+  server' in a project specific comint buffer")

--- a/layers/+lang/flow-type/funcs.el
+++ b/layers/+lang/flow-type/funcs.el
@@ -1,3 +1,6 @@
+(defun flow-type/--no-auto-start-arg ()
+  (if flow-type/no-auto-start "--no-auto-start" ""))
+
 (defun flow-type/call-process-on-buffer-to-string (command)
   (with-output-to-string
     (call-process-region (point-min) (point-max) shell-file-name nil standard-output nil shell-command-switch command)))
@@ -49,8 +52,10 @@
 
 (defun flow-type/type-at-cursor ()
   (let ((output (flow-type/call-process-on-buffer-to-string
-                 (format "%s type-at-pos --retry-if-init=false --json %d %d"
+                 (format "%s type-at-pos %s --retry-if-init=false %s --json %d %d"
                          (flow-type/flow-binary)
+                         (if buffer-file-name (concat "--path " buffer-file-name) "")
+                         (flow-type/--no-auto-start-arg)
                          (line-number-at-pos) (+ (current-column) 1)))))
     (unless (string-match "\w*flow is still initializing" output)
       (flow-type/describe-info-object (json-read-from-string output)))))
@@ -62,8 +67,9 @@
 (defun flow-type/jump-to-definition ()
   (interactive)
   (let ((output (flow-type/call-process-on-buffer-to-string
-                 (format "%s get-def --json --path %s %d %d"
+                 (format "%s get-def --quiet %s --json --path %s %d %d"
                          (flow-type/flow-binary)
+                         (flow-type/--no-auto-start-arg)
                          (buffer-file-name)
                          (line-number-at-pos) (+ (current-column) 1)))))
     (let* ((result (json-read-from-string output))
@@ -74,3 +80,48 @@
             (goto-char (point-min))
             (forward-line (1- (alist-get 'line result)))
             (forward-char (1- (alist-get 'start result))))))))
+
+(defun flow-type/project-root ()
+  (let ((dir (and buffer-file-name
+                  (locate-dominating-file buffer-file-name ".flowconfig"))))
+    (unless dir
+      (error "No .flowconfig found"))
+    dir))
+
+(defun flow-type/start-server ()
+  (ansi-color-for-comint-mode-on)
+  (let ((default-directory (flow-type/project-root)))
+    (make-comint (concat "flow " default-directory) (flow-type/flow-binary) nil "server")))
+
+(defun flow-type/show-start-server ()
+  (interactive)
+  (ansi-color-for-comint-mode-on)
+  (let ((buf (flow-type/start-server)))
+    (pop-to-buffer buf)))
+
+(defun flow-type/ensure-server-buffer ()
+  (let ((default-directory (ignore-errors (flow-type/project-root))))
+    (when default-directory (flow-type/start-server))))
+
+(defun flow-type/compile (name command)
+  (interactive)
+  (let* ((default-directory (flow-type/project-root))
+         (bname (concat "*" name " " default-directory "*"))
+         (buf (get-buffer bname)))
+    (when buf
+      (kill-buffer buf))
+    (with-current-buffer (compile (format "%s %s" (flow-type/flow-binary) command))
+      (rename-buffer bname))))
+
+(defun flow-type/status ()
+  (interactive)
+  (flow-type/compile
+   "flow status"
+   (format "status --quiet %s --show-all-errors"
+           (flow-type/--no-auto-start-arg))))
+
+(defun flow-type/check ()
+  (interactive)
+  (flow-type/compile
+   "flow check"
+   "check --quiet --show-all-errors"))

--- a/layers/+lang/flow-type/packages.el
+++ b/layers/+lang/flow-type/packages.el
@@ -26,6 +26,18 @@
   (spacemacs|add-company-backends :backends company-flow :modes js2-mode react-mode))
 
 (defun flow-type/post-init-js2-mode()
+  (spacemacs/declare-prefix-for-mode 'js2-mode "mf" "flow" "flow type checker commands")
+  (spacemacs/set-leader-keys-for-major-mode 'js2-mode
+    "fs" 'flow-type/show-start-server
+    "fc" 'flow-type/status
+    "fC" 'flow-type/check)
+  (when flow-type/no-auto-start
+    (add-to-list 'flycheck-javascript-flow-args "--no-auto-start"))
+  (when (eq 'process flow-type/no-auto-start)
+    (add-hook 'js2-mode-hook 'flow-type/ensure-server-buffer))
+  (add-to-list 'compilation-error-regexp-alist-alist
+               '(flow "^\\([^:\n]+\\):\\([0-9]+\\)$" 1 2))
+  (add-to-list 'compilation-error-regexp-alist 'flow)
   (add-to-list 'spacemacs-jump-handlers-js2-mode 'flow-type/jump-to-definition))
 
 ;; There's no flow-type/post-init-react hook, so we have to do this dance:


### PR DESCRIPTION
I'm not terribly familiar with the spacemacs way of doing things, so feel free to reject / change / tidy up.

- Option to add `--no-auto-start` to the relevant commands.
- Option to auto-start `flow server` in a project specific comint buffer.
- Compile commands and bindings for `flow status` and `flow check`.

Also added `--quiet` to `flow-type/jump-to-definition` because it occasionally spits out server init information which breaks json parsing.